### PR TITLE
Add a spec for the Content Object Store

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+import { expect } from "@playwright/test";
+
 function publishingAppUrl(appName) {
   return `https://${appName}.${process.env.PUBLISHING_DOMAIN}`;
 }
@@ -8,4 +10,13 @@ async function logIntoSignon(page) {
   await page.getByRole("button", { name: "Sign in" }).click();
 }
 
-export { publishingAppUrl, logIntoSignon };
+async function waitForUrlToBeAvailable(page, url) {
+  await expect(async () => {
+    url = `${url}?cacheBust=${new Date().getTime()}`;
+    const response = await page.request.get(url);
+    expect(response.status()).toBe(200);
+  }).toPass();
+  return url;
+}
+
+export { publishingAppUrl, logIntoSignon, waitForUrlToBeAvailable };

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -1,0 +1,133 @@
+import { expect } from "@playwright/test";
+import { test } from "../lib/cachebust-test";
+import { publishingAppUrl, waitForUrlToBeAvailable } from "../lib/utils";
+
+test.describe("Content Block Manager", { tag: ["@app-content-object-store"] }, () => {
+  let embedCode;
+  let value;
+
+  const contentBlockPath = `${publishingAppUrl("whitehall-admin")}/content-block-manager/content-block/18`;
+  const whitehallPath = "/government/admin/news/1658299";
+  const mainstreamPath = "/editions/663e33d76187a0001afaf022";
+
+  test.beforeAll(async ({ page }) => {
+    await page.goto(contentBlockPath);
+
+    const row = page.getByTestId("rate_1_amount");
+    value = await row.locator(".govuk-summary-list__value").first().textContent();
+    embedCode = await row.getAttribute("data-embed-code");
+  });
+
+  test.describe("When embedding content in Whitehall", () => {
+    test.use({ baseURL: publishingAppUrl("whitehall-admin") });
+
+    test("Can embed content in Whitehall", async ({ page }) => {
+      await page.goto(whitehallPath);
+      await page.getByRole("button", { name: "Edit draft" }).click();
+
+      await page.getByLabel("Body (required)").fill("");
+      await page.getByLabel("Body (required)").fill(embedCode);
+
+      await page.getByRole("button", { name: "Save and go to document" }).click();
+
+      const url = await waitForUrlToBeAvailable(
+        page,
+        await page.getByRole("link", { name: "Preview on website" }).getAttribute("href")
+      );
+
+      await page.goto(url);
+      await expect(page.getByText(value)).toBeVisible();
+    });
+  });
+
+  test.describe("When embedding content in Mainstream", () => {
+    test.use({ baseURL: publishingAppUrl("publisher") });
+
+    test("Can embed content in Mainstream", async ({ page }) => {
+      await page.goto(mainstreamPath);
+
+      await page.getByLabel("More information").fill("");
+      await page.getByLabel("More information").fill(embedCode);
+
+      await page.getByRole("button", { name: "Save" }).click();
+
+      const url = await waitForUrlToBeAvailable(
+        page,
+        await page.getByRole("link", { name: "Preview" }).getAttribute("href")
+      );
+
+      await page.goto(url);
+      await expect(page.getByText(value)).toBeVisible();
+    });
+  });
+
+  test.describe("When content block changes", () => {
+    let newValue;
+
+    test.beforeAll(async ({ page }) => {
+      // Set a new random value between £100 and £200
+      newValue = `£${(Math.random() * (100.0 - 200.0) + 200.0).toFixed(2)}`;
+      await page.goto(contentBlockPath);
+
+      await page.getByRole("button", { name: "Edit pension" }).click();
+
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
+      await page.getByLabel("Amount").click();
+      await page.getByLabel("Amount").fill(newValue);
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByLabel("No").check();
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByLabel("Publish the edit now").check();
+      await page.getByRole("button", { name: "Save and continue" }).click();
+
+      await page.getByLabel("confirm").check();
+      await page.getByRole("button", { name: "Publish" }).click();
+    });
+
+    test.describe("For Whitehall content", () => {
+      test.use({ baseURL: publishingAppUrl("whitehall-admin") });
+
+      test("Whitehall value changes", async ({ page }) => {
+        await page.goto(whitehallPath);
+
+        const url = await waitForUrlToBeAvailable(
+          page,
+          await page.getByRole("link", { name: "Preview on website" }).getAttribute("href")
+        );
+
+        await expect(async () => {
+          await page.goto(`${url}&cacheBust=${new Date().getTime()}`);
+          await expect(page.getByText(newValue)).toBeVisible();
+        }).toPass();
+      });
+    });
+
+    test.describe("For Mainstream content", () => {
+      test.use({ baseURL: publishingAppUrl("publisher") });
+
+      test("Mainstream value changes", async ({ page }) => {
+        await page.goto(mainstreamPath);
+
+        const url = await waitForUrlToBeAvailable(
+          page,
+          await page.getByRole("link", { name: "Preview" }).getAttribute("href")
+        );
+
+        await expect(async () => {
+          await page.goto(`${url}&cacheBust=${new Date().getTime()}`);
+          await expect(page.getByText(newValue)).toBeVisible();
+        }).toPass();
+      });
+    });
+  });
+});


### PR DESCRIPTION
https://trello.com/c/DOjHweAf/945-look-into-e2e-testing

This adds some specs to test the content object manager features in Publishing, namely:

- When a block is embedded, the value is shown on a page published in the draft stack in both Whitehall and Mainstream; and
- When a block is updated, the value is updated in the draft stack

To achieve this, we use a draft, test page in both publishing apps that is not published and test only on the draft stack (similar to https://github.com/alphagov/govuk-e2e-tests/pull/135). This allows us to alter state, but in a way that we can do in production without altering publicly visible information on GOV.UK.

I've also added a `waitForUrlToBeAvailable` helper function that polls a URL (with a cache-busting query string) to wait for it to exist before continuing.
