### PR TITLE
Make licensing admin test less flakey

### DIFF
--- a/tests/licensing.spec.js
+++ b/tests/licensing.spec.js
@@ -38,7 +38,7 @@ test.describe("Licensing admin", () => {
       await page.goto("/");
       await page.getByRole("button", { name: "Login" }).click();
 
-      await expect(page.getByLabel("Filter by keyword in")).toBeVisible();
+      await expect(page.getByRole("link", { name: "Applications" })).toBeVisible();
     }
   );
 });


### PR DESCRIPTION
This selects an element that is rendered immediately on page load.