### PR TITLE
Make tests run only in suitable environments

### DIFF
--- a/tests/cdn.spec.js
+++ b/tests/cdn.spec.js
@@ -86,7 +86,7 @@ test.describe("CDN", { tag: ["@domain-www"] }, () => {
     expect(response.headers()["location"]).toBe(expectedURL);
   });
 
-  test("redirect service domain to www domain", { tag: ["@production"] }, async ({ page }) => {
+  test("redirect service domain to www domain", { tag: ["@not-staging", "@not-integration"] }, async ({ page }) => {
     const response = await page.request.get("https://service.gov.uk", { maxRedirects: 0 });
     expect(response.status()).toBe(302);
     expect(response.headers()["location"]).toBe("https://www.gov.uk");

--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
-test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
+test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
   test("Can view a static page", async ({ page }) => {
     await page.goto("/chat/about");
     await expect(page.getByRole("heading", { name: "About GOV.UK Chat" })).toBeVisible();


### PR DESCRIPTION
GOV.UK Chat is not yet available in production and service.gov.uk redirects aren't configured in staging and integration.