### PR TITLE
Finder Frontend: Update site search test

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -19,11 +19,11 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
   });
 
-  test("Check the frontend can talk to Search API", async ({ page }) => {
+  test("Can use site search and receive results", async ({ page }) => {
     await page.goto("/");
     const searchBox = page.getByRole("search");
     await searchBox.getByRole("searchbox", { name: "Search" }).fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
-    await expect(page.getByRole("region", { name: "Search search results" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Sign in to your Universal Credit account" })).toBeVisible();
   });
 });


### PR DESCRIPTION
This tests for a (broken and mangled) ARIA region that no longer exists in our upcoming new UI for site search.

Instead, we should be looking for a stable long-lived link that has the added benefit of also verifying results are coming back.