### PR TITLE
Reapply Mainstream Publisher test from Smokey

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -11,10 +11,9 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
     await expect(page.locator("#publication-list-container")).toBeVisible();
   });
 
-  /* This mutates server side state
   test(
-    "should see that the edition has been deleted",
-    { tag: ["@app-publisher", "@app-publishing-api", "@notproduction"] },
+    "Can add and delete an artefact in publisher",
+    { tag: ["@app-publisher", "@app-publishing-api", "@not-production"] },
     async ({ page }) => {
       // Go to the "publisher" landing page
       await page.goto("/");
@@ -35,5 +34,4 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
       await expect(page.getByText("Edition deleted")).toBeVisible();
     }
   );
-  */
 });


### PR DESCRIPTION
This test was ported across from Smokey, but commented-out. We (the
 Mainstream Publishing Experience team) would like this test reinstated
 as it protects against issues when upgrading the Mongo driver that
 aren't picked up otherwise.

It does modify state (by creating, and then deleting a Guide), which is
 why it is tagged not to run in production.