### PR TITLE
Add backend app tags to relevant frontend tests

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -66,7 +66,7 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByText("Electoral Services Dudley")).toBeVisible();
   });
 
-  test("find your local council", async ({ page }) => {
+  test("find your local council", { tag: ["@app-local-links-manager", "@app-locations-api"] }, async ({ page }) => {
     await page.goto("/find-local-council");
     await expect(page.getByRole("heading", { name: "Find your local council" })).toBeVisible();
     await page.getByLabel("Enter a postcode").fill("WV14 8TU");
@@ -120,7 +120,7 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByRole("button", { name: "Start now" })).toBeVisible();
   });
 
-  test("local transaction page", async ({ page }) => {
+  test("local transaction page", { tag: ["@app-local-links-manager", "@app-locations-api"] }, async ({ page }) => {
     await page.goto("/pay-council-tax");
     await expect(page.getByRole("heading", { name: "Pay your Council Tax" })).toBeVisible();
     await page.getByLabel("Enter a postcode").fill("WC2B 6NH");
@@ -128,7 +128,7 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByText("London Borough of Camden", { exact: true })).toBeVisible();
   });
 
-  test("place page", async ({ page }) => {
+  test("place page", { tag: ["@app-places-manager", "@app-locations-api"] }, async ({ page }) => {
     await page.goto("/ukonline-centre-internet-access-computer-training");
     await expect(page.getByRole("heading", { name: "Online Centres Network" })).toBeVisible();
     await page.getByLabel("Enter a postcode").fill("WC2B 6NH");


### PR DESCRIPTION
- We want to make sure that when these apps are deployed frontend can still access them.