### PR TITLE
Homepage search test compatible with autocomplete

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -22,7 +22,7 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
   test("Can use site search and receive results", async ({ page }) => {
     await page.goto("/");
     const searchBox = page.getByRole("search");
-    await searchBox.getByRole("searchbox", { name: "Search" }).fill("Universal Credit");
+    await searchBox.getByLabel("Search").fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
     await expect(page.getByRole("link", { name: "Sign in to your Universal Credit account" })).toBeVisible();
   });


### PR DESCRIPTION
With the introduction of autocomplete for GOV.UK Site Search this test has started failing. The reason this is failing is that the auocomplete component makes use of an input with a role of "combobox" and thus locating an element with a role of "searchbox" fails.

Rather than changing the role to "combobox" I have taken the approach of finding by label so that this can work with both input types. The reason for is that autcomplete is new and we have set-up a mechanism so it can be turned off quickly [1], should we do that it would be frustrating if the e2e tests started failing.

[1]: https://github.com/alphagov/govuk-helm-charts/pull/2832