### PR TITLE
Move search-api test

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -160,4 +160,10 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await page.getByRole("tab", { name: "Gogledd Iwerddon" }).click();
     await expect(page.getByRole("heading", { name: "Yr ŵyl banc nesaf yng Ngogledd Iwerddon yw" })).toBeVisible();
   });
+
+  test("Check the frontend can talk to Search API", { tag: ["@worksonmirror"] }, async ({ page }) => {
+    await page.goto("/government/get-involved");
+    await expect(page.getByRole("heading", { name: "Recently opened" })).toBeVisible();
+    await expect(page.locator("main > div").nth(3).locator(".gem-c-document-list__item-title")).toHaveCount(3);
+  });
 });

--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -19,12 +19,6 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
     await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
   });
 
-  test("Check the frontend can talk to Search API", { tag: ["@worksonmirror"] }, async ({ page }) => {
-    await page.goto("/government/get-involved");
-    await expect(page.getByRole("heading", { name: "Recently opened" })).toBeVisible();
-    await expect(page.locator(".get-involved > div").nth(3).locator(".gem-c-document-list__item-title")).toHaveCount(3);
-  });
-
   test("Check a travel advice country page loads", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/foreign-travel-advice/luxembourg");
     await expect(page.getByRole("heading", { name: "Luxembourg" })).toBeVisible();


### PR DESCRIPTION
- government-frontend doesn't use search api as of https://github.com/alphagov/government-frontend/pull/3419
- frontend uses it now, but also we've removed the schema-name identifiers from main, so we have to update the locator.