### PR TITLE
Test chat against publishing host name

### DIFF
--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
-test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
+test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can view a static page", async ({ page }) => {

--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -3,6 +3,8 @@ import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
 test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
+  test.use({ baseURL: publishingAppUrl("chat") });
+
   test("Can view a static page", async ({ page }) => {
     await page.goto("/chat/about");
     await expect(page.getByRole("heading", { name: "About GOV.UK Chat" })).toBeVisible();


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

GOV.UK Chat is no longer hosted on [www.gov.uk](http://www.gov.uk/) and is available, behind
signon, on chat.publishing.service.gov.uk.