### PR TITLE
Add full e2e test from publishing to frontend

### DIFF
--- a/tests/content-data.spec.js
+++ b/tests/content-data.spec.js
@@ -21,6 +21,6 @@ test.describe("Content Data", { tag: ["@app-content-data"] }, () => {
       .filter({ hasText: "Unique page views" })
       .locator(".app-c-glance-metric__figure")
       .innerText();
-    await expect(parseInt(pageViews)).toBeGreaterThan(0);
+    expect(parseInt(pageViews)).toBeGreaterThan(0);
   });
 });

--- a/tests/whitehall.spec.js
+++ b/tests/whitehall.spec.js
@@ -11,4 +11,40 @@ test.describe("Whitehall", { tag: ["@app-whitehall"] }, () => {
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
     await expect(page.getByText("My draft documents")).toBeVisible();
   });
+
+  test(
+    "Can update an edition and preview it on the frontend",
+    { tag: ["@publishing-app", "@app-publishing-api"] },
+    async ({ page }) => {
+      // path to an old, unused, test document we can freely edit in draft mode
+      const testDocumentPath = "/government/admin/publications/572828";
+      // the value we're going to check makes it through to the frontend
+      const lastUpdatedMessage = `Updated: ${new Date().toISOString()}`;
+
+      // Update the draft
+      await page.goto(testDocumentPath);
+      await page.getByRole("button", { name: "Edit draft" }).click();
+      await page.getByLabel("Body (required)").fill(lastUpdatedMessage);
+      await page.getByRole("button", { name: "Save and go to document summary" }).click();
+      await expect(page.getByText("Your document has been saved")).toBeVisible();
+
+      // Verify the draft has been updated, allowing some retries because
+      // propagating through to the frontend can take a little time
+      const previewLink = await page.locator("text=Preview on website (opens in new tab)").getAttribute("href");
+      const maxRetries = 10;
+      for (let retries = 0; retries < maxRetries; retries++) {
+        await page.goto(previewLink + "?cachebust=" + Date.now());
+        try {
+          await expect(page.getByText(lastUpdatedMessage)).toBeVisible({ timeout: 1000 });
+          break; // Exit loop if found
+        } catch {
+          console.log(`Retry ${retries + 1}/${maxRetries}: Update not found, retrying...`);
+          if (retries === maxRetries - 1) {
+            // eslint-disable-line playwright/no-conditional-in-test
+            throw new Error(`Updated message did not appear in preview after ${maxRetries} seconds`);
+          }
+        }
+      }
+    }
+  );
 });


### PR DESCRIPTION
Trello: https://trello.com/c/H4gmTEtf/3489-explore-adding-full-e2e-publishing-test

We currently lack any automated test that gives us confidence that publishing is working end to end, i.e. that an update from a publishing app becomes visible on the frontend. Adding such a test was highlighted as a recent [incident action](https://docs.google.com/document/d/14Hi5AkI6nf0l7Ot6KhjHu53Yq81F2vuRjjyMFtJWLcc/edit).

This commit adds a test that:

- Visits an existing 'test' document in Whitehall (available in all environments)
- Saves an edit to its draft content
- Verifies that the updated content is visible on the draft preview of that content

This tests the 'save draft' aspects of the publishing platform, which is a reasonably thorough verification that the connection from publishing app, to Publishing API, to Content Store is working. It doesn't test the 'publish' action, but it doesn't really need to, since that would just test the same aspects of the publishing platform as above, only with a different final destination (live content store instead of draft content store). It also raises questions about how much of this automated test activity should be public-facing, which is a can of worms we can just avoid by sticking to the draft stack.

This has been successfully tested locally, against integration. I've also manually recreated the steps against the document on production, to double check that there are no ill side-effects.

<details>
<summary>yarn playwright test tests/whitehall.spec.js -g "Can update an edition and preview it on the frontend" --headed</summary>
yarn run v1.22.19
$ /Users/christopher.ashton/govuk/govuk-e2e-tests/node_modules/.bin/playwright test tests/whitehall.spec.js -g 'Can update an edition and preview it on the frontend' --headed

Running 2 tests using 1 worker

  ✓  1 [setup] › tests/auth.setup.js:7:6 › authenticate (1.2s)
  ✓  2 [main] › tests/whitehall.spec.js:15:7 › Whitehall › Can update an edition and preview it on the frontend @app-whitehall @publishing-app @app-publishing-api (7.6s)

  2 passed (11.0s)
✨  Done in 11.64s.
</details>

<details>
<summary>Unsuccessful run when changing `expect(page.getByText(` to look for "sausage"</summary>
$ yarn playwright test tests/whitehall.spec.js -g "Can update an edition and preview it on the frontend" --headed
yarn run v1.22.19
$ /Users/christopher.ashton/govuk/govuk-e2e-tests/node_modules/.bin/playwright test tests/whitehall.spec.js -g 'Can update an edition and preview it on the frontend' --headed

Running 2 tests using 1 worker

  ✓  1 [setup] › tests/auth.setup.js:7:6 › authenticate (1.1s)
  ✘  2 [main] › tests/whitehall.spec.js:15:7 › Whitehall › Can update an edition and preview it on the frontend @app-whitehall @publishing-app @app-publishing-api (19.2s)
Retry 1/10: Update not found, retrying...
Retry 2/10: Update not found, retrying...
Retry 3/10: Update not found, retrying...
Retry 4/10: Update not found, retrying...
Retry 5/10: Update not found, retrying...
Retry 6/10: Update not found, retrying...
Retry 7/10: Update not found, retrying...
Retry 8/10: Update not found, retrying...
Retry 9/10: Update not found, retrying...
Retry 10/10: Update not found, retrying...


  1) [main] › tests/whitehall.spec.js:15:7 › Whitehall › Can update an edition and preview it on the frontend @app-whitehall @publishing-app @app-publishing-api 

    Error: Updated message did not appear in preview after 10 seconds

      41 |           console.log(`Retry ${retries + 1}/${maxRetries}: Update not found, retrying...`);
      42 |           if (retries === maxRetries - 1) { // eslint-disable-line playwright/no-conditional-in-test
    > 43 |             throw new Error(`Updated message did not appear in preview after ${maxRetries} seconds`);
         |                   ^
      44 |           }
      45 |         }
      46 |       }
        at /Users/christopher.ashton/govuk/govuk-e2e-tests/tests/whitehall.spec.js:43:19

  Slow test file: [main] › tests/whitehall.spec.js (19.2s)
  Consider running tests from slow files in parallel, see https://playwright.dev/docs/test-parallel.
  1 failed
    [main] › tests/whitehall.spec.js:15:7 › Whitehall › Can update an edition and preview it on the frontend @app-whitehall @publishing-app @app-publishing-api 
  1 passed (22.1s)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
</details>