### PR TITLE
Update expected text on get involved page

### DIFF
--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -5,11 +5,7 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
   test("Check the frontend can talk to Content Store", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/government/get-involved");
     await expect(page.getByRole("heading", { name: "Get involved" })).toBeVisible();
-    await expect(
-      page.getByText(
-        "Find out how you can engage with government directly, and take part locally, nationally or internationally."
-      )
-    ).toBeVisible();
+    await expect(page.getByText("Find out how to get involved with the work of the government.")).toBeVisible();
   });
 
   test("Check the frontend can talk to Email Alert API", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {


### PR DESCRIPTION
The text on this page has been updated. This commit updates the test to reflect the new text.

https://github.com/alphagov/frontend/pull/4681/files#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7