### PR TITLE
Update government frontend frontend tests

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -88,6 +88,19 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByRole("link", { name: "Zimbabwe" })).toBeHidden();
   });
 
+  test("Check a travel advice country page loads", { tag: ["@worksonmirror"] }, async ({ page }) => {
+    await page.goto("/foreign-travel-advice/luxembourg");
+    await expect(page.getByRole("heading", { name: "Luxembourg" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Warnings and insurance" })).toBeVisible();
+  });
+
+  test("Check links to Email Alert Frontend work", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
+    await page.goto("/foreign-travel-advice/turkey");
+    await page.getByRole("link", { name: "Get email alerts" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
+  });
+
   test("signin", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/sign-in");
     await expect(page.getByRole("heading", { name: "Sign in to a service" })).toBeVisible();

--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -3,22 +3,21 @@ import { test } from "../lib/cachebust-test";
 
 test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () => {
   test("Check the frontend can talk to Content Store", { tag: ["@worksonmirror"] }, async ({ page }) => {
-    await page.goto("/government/get-involved");
-    await expect(page.getByRole("heading", { name: "Get involved" })).toBeVisible();
-    await expect(page.getByText("Find out how to get involved with the work of the government.")).toBeVisible();
+    await page.goto("/government/topical-events/2014-overseas-territories-joint-ministerial-council/about");
+    await expect(
+      page.getByRole("heading", { name: "Priorities for the Overseas Territories Joint Ministerial Council 2014" })
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "The UK and the Overseas Territories share a vision for the Territories as vibrant and flourishing communities"
+      )
+    ).toBeVisible();
   });
 
-  test("Check the frontend can talk to Email Alert API", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
-    await page.goto("/foreign-travel-advice/turkey");
-    await page.getByRole("link", { name: "Get email alerts" }).click();
-    await page.getByRole("button", { name: "Continue" }).click();
-    await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
-  });
-
-  test("Check a travel advice country page loads", { tag: ["@worksonmirror"] }, async ({ page }) => {
-    await page.goto("/foreign-travel-advice/luxembourg");
-    await expect(page.getByRole("heading", { name: "Luxembourg" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Warnings and insurance" })).toBeVisible();
+  test("Check links to Email Alert Frontend work", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
+    await page.goto("/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2");
+    await page.getByRole("button", { name: "Get emails about this page" }).first().click();
+    await expect(page.getByText("You need a GOV.UK One Login to get these emails.")).toBeVisible();
   });
 
   test("Check that Service Manuals load", { tag: ["@worksonmirror"] }, async ({ page }) => {


### PR DESCRIPTION

The consolidation work has moved some routes to Frontend that the E2E test for government-frontend was using, so they would still pass even if government-frontend had fallen over. Update both test suites to reflect current situation.