### PR TITLE
Remove publishing-api tag from places-manager-spec

### DIFF
--- a/tests/places-manager.spec.js
+++ b/tests/places-manager.spec.js
@@ -5,7 +5,7 @@ import { publishingAppUrl } from "../lib/utils";
 test.describe("Places Manager", { tag: ["@app-places-manager"] }, () => {
   test.use({ baseURL: publishingAppUrl("places-manager") });
 
-  test("Can log in to Places Manager", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
+  test("Can log in to Places Manager", { tag: ["@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Places Manager")).toBeVisible();
     await expect(page.getByText("All services")).toBeVisible();


### PR DESCRIPTION

It doesn't seem that places-manager and publishing-api have ever depended on one another, the tag was added to the old smoketests by mistake (https://github.com/alphagov/smokey/commit/62135b65516ea9847ada6f236bac2417fe2c0e35)

