### PR TITLE
Move service manual homepage test

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -179,4 +179,9 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByRole("heading", { name: "Recently opened" })).toBeVisible();
     await expect(page.locator("main > div").nth(3).locator(".gem-c-document-list__item-title")).toHaveCount(3);
   });
+
+  test("Check that Service Manuals load", { tag: ["@worksonmirror"] }, async ({ page }) => {
+    await page.goto("/service-manual");
+    await expect(page.getByRole("heading", { name: "Service Manual" })).toBeVisible();
+  });
 });

--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -19,9 +19,4 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
     await page.getByRole("button", { name: "Get emails about this page" }).first().click();
     await expect(page.getByText("You need a GOV.UK One Login to get these emails.")).toBeVisible();
   });
-
-  test("Check that Service Manuals load", { tag: ["@worksonmirror"] }, async ({ page }) => {
-    await page.goto("/service-manual");
-    await expect(page.getByRole("heading", { name: "Service Manual" })).toBeVisible();
-  });
 });


### PR DESCRIPTION
## What / why
Update service manual homepage tests to move them from `government-frontend` to `frontend`.

`government-frontend` isn't rendering /service-manual as of https://github.com/alphagov/government-frontend/pull/3628

Trello card: https://trello.com/c/ANPt33UZ/508-move-route-service-manual-homepage-only-from-government-frontend-to-frontend