### PR TITLE
Fix flaky Publisher test

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -19,12 +19,13 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
       await page.goto("/");
 
       // Add an artefact
+      const title = `Smokey Guide ${crypto.randomUUID()}`;
       await page.getByRole("link", { name: "Add artefact" }).click();
-      await page.getByLabel("Title").fill("Smokey Guide");
-      await page.getByLabel("Slug").fill("smokey-guide");
+      await page.getByLabel("Title").fill(title);
+      await page.getByLabel("Slug").fill(title.toLowerCase().replace(" ", "-"));
       await page.getByLabel("Format").selectOption("Guide");
       await page.getByRole("button", { name: "Save and go to item" }).click();
-      await expect(page.getByRole("heading", { name: "Smokey Guide" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: title })).toBeVisible();
 
       // Delete the artefact
       await page.getByRole("tab", { name: "Admin" }).click();


### PR DESCRIPTION
[Trello](https://trello.com/c/xFZ5Fx1D/1657-looks-into-deploy-failures-for-publishing-api)

We're seeing a lot of failed Argo workflow runs in Publishing API each day, and a large proportion are because of the Publisher end-to-end test failing. We've noticed that multiple runs fail at almost the same time

We've found/note that:
- multiple runs fail with no more than a few minutes before and/or after each other throughout the day
- deleting the artefact created by the Smokey user in Publisher and then re-running the workflow can make the test pass
- the title of the artefact created in the test is not unique between runs
- the failed runs typically start appearing around 09:30/10:00 each morning, which we believe corresponds with an increase in Dependabot activity

Our theory then is that multiple overlapping runs might be creating race conditions and failing either to create or delete the same artefact or at least one with the same title

This makes the title of the artefact and its slug unique to avoid multiple runs acting on the same artefact