### PR TITLE
Fix Publisher end-to-end test

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";

--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -23,7 +23,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
       const title = `Smokey Guide ${crypto.randomUUID()}`;
       await page.getByRole("link", { name: "Add artefact" }).click();
       await page.getByLabel("Title").fill(title);
-      await page.getByLabel("Slug").fill(title.toLowerCase().replace(" ", "-"));
+      await page.getByLabel("Slug").fill(title.toLowerCase().replaceAll(" ", "-"));
       await page.getByLabel("Format").selectOption("Guide");
       await page.getByRole("button", { name: "Save and go to item" }).click();
       await expect(page.getByRole("heading", { name: title })).toBeVisible();


### PR DESCRIPTION
[Trello](https://trello.com/c/xFZ5Fx1D/1657-look-into-deploy-failures-for-publishing-api)

We attempted to fix some flakiness in 4ed3493138369fabf2a8987d9f705605409e5c42 but introduced a couple of mistakes. We're slightly surprised by the missing import not being picked up by the linter, but not the `replace`/`replaceAll` mistake. The end-to-end tests don't run in CI, so this wasn't spotted until it was deployed. We've run this locally using the Smokey user in integration to confirm it now works