### PR TITLE
Add wait for correct URL in search test

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -24,6 +24,7 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     const searchBox = page.getByRole("search");
     await searchBox.getByLabel("Search").fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
+    await page.waitForURL("**/search/all?keywords=Universal+Credit**");
     await expect(page.getByRole("link", { name: "Sign in to your Universal Credit account" })).toBeVisible();
   });
 });


### PR DESCRIPTION
- Adds a `waitForURL` to one of the `finder-frontend` tests
- The test is failing on deployment to `production`
- We're not entirely sure why it's failing, but when testing locally it looks like after clicking the "search" button in the test, the test might continue its checks before the page has fully loaded.