### PR TITLE
Change site search result test

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -24,7 +24,6 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     const searchBox = page.getByRole("search");
     await searchBox.getByLabel("Search").fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
-    await page.waitForURL("**/search/all?keywords=Universal+Credit**");
-    await expect(page.getByRole("link", { name: "Sign in to your Universal Credit account" })).toBeVisible();
+    await expect(page.locator("#app-all-content-finder a[href='/universal-credit']")).toBeVisible();
   });
 });


### PR DESCRIPTION
## What / Why

- A test for `finder-frontend` search was looking for the `Sign in to your Universal Credit account` link when you search for "Universal Credit"
- However, Google can sometimes change the ranking of search results on `staging`/`integration` to demonstrate new features. This can make this test fail as the `Sign in to your Universal Credit account` link can disappear from page 1 of the results.
- Therefore we should use a search result that is a lot more likely to exist on Page 1 when searching for "Universal Credit"
- This commit changes the test to look for the `/universal-credit` landing page instead, which is a lot more likely to always exist when searching for "Universal Credit".
- It also makes the test specifically look for the link within the search results. This prevents this test from always passing if that link was added to the header/footer.