### PR TITLE
Remediate Incomplete regular expression for hostnames

### DIFF
--- a/tests/licensing.spec.js
+++ b/tests/licensing.spec.js
@@ -23,7 +23,7 @@ test.describe("Licensing", () => {
 
     await expect(page.getByRole("heading", { name: "Pay the licence fee" })).toBeVisible();
     await page.getByRole("link", { name: "Continue to WorldPay website" }).click();
-    await expect(page).toHaveURL(/.worldpay.com/);
+    await expect(page).toHaveURL(/\.worldpay\.com/);
   });
 });
 


### PR DESCRIPTION
CodeQL alerted: This regular expression has an unescaped '.' before 'worldpay.com', so it might match more hosts than expected. Escape the dot (.) so it matches a literal dot, not any character. It was used in a test so was not going to exploited"

https://github.com/alphagov/govuk-e2e-tests/security/code-scanning/1