### PR TITLE
Temporarily reduce specificity of homepage test

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -5,9 +5,7 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
   test("homepage", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page).toHaveTitle(/Welcome to GOV.UK/);
-    await expect(
-      page.getByRole("heading", { name: "GOV.UK - The best place to find government services and information" })
-    ).toBeVisible();
+    await expect(page.getByText("The best place to find government services and information")).toBeVisible();
   });
 
   test("help page", { tag: ["@worksonmirror"] }, async ({ page }) => {


### PR DESCRIPTION
To reduce complexity in rolling out a change to the homepage tomorrow. To be replaced with https://github.com/alphagov/govuk-e2e-tests/pull/222