### PR TITLE
Add check for class on new design system component for publications page

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -9,7 +9,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Publisher")).toBeVisible();
-    await expect(page.locator("#publication-list-container")).toBeVisible();
+    await expect(page.locator("#publication-list-container").or(page.locator(".publications-table"))).toBeVisible();
   });
 
   test(


### PR DESCRIPTION
Ensure that e2e tests will run successfully if the flipflop toggle for the new design system version of the publications page is enabled/disabled. The legacy check will be removed after enabling the toggle on by default