### PR TITLE
remove check for legacy publications page

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -9,7 +9,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Publisher")).toBeVisible();
-    await expect(page.locator("#publication-list-container").or(page.locator(".publications-table"))).toBeVisible();
+    await expect(page.locator(".publications-table")).toBeVisible();
   });
 
   test(


### PR DESCRIPTION
Post release, the toggle is defaulted to on, so checking for the legacy system is no longer required.