### PR TITLE
Add check for both progression and regression for design system toggle on publications page

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -9,7 +9,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Publisher")).toBeVisible();
-    await expect(page.locator(".publications-table")).toBeVisible();
+    await expect(page.locator("#publication-list-container").or(page.locator(".publications-table"))).toBeVisible();
   });
 
   test(


### PR DESCRIPTION
The toggle for the design system on the publications page needs to re-enabled by default. The tests need to support checking on/off so that no e2e tests fail during the release process