### PR TITLE
Remove breaking expectation for SP [WHIT-2027]

### DIFF
--- a/tests/specialist-publisher.spec.js
+++ b/tests/specialist-publisher.spec.js
@@ -8,6 +8,5 @@ test.describe("Specialist Publisher", { tag: ["@app-specialist-publisher"] }, ()
   test("Can log in to Specialist Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Specialist Publisher")).toBeVisible();
-    await expect(page.getByText("Add another")).toBeVisible();
   });
 });


### PR DESCRIPTION
Latest changes for the Design System release have introduced a change to the routing in Specialist Publisher, so that the "/" route redirects to "/finders" by default, which is the index page of all finders, rather than the first finder the user has access to. Because of this, no "Add another" can be found on the page.

Removing this to unblock pub-api deployments, as well as the release of the DS itself.

Will reintroduce the correct expectation after the merge.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2027)