### PR TITLE
Add expectation for specialist publisher [WHIT-2027]

### DIFF
--- a/tests/specialist-publisher.spec.js
+++ b/tests/specialist-publisher.spec.js
@@ -8,5 +8,6 @@ test.describe("Specialist Publisher", { tag: ["@app-specialist-publisher"] }, ()
   test("Can log in to Specialist Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("Specialist Publisher")).toBeVisible();
+    await expect(page.getByText("All finders")).toBeVisible();
   });
 });


### PR DESCRIPTION
This was [removed](https://github.com/alphagov/govuk-e2e-tests/pull/251) for a design system launch. Adding expectation for updated page content.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2027)