### PR TITLE
[Do Not Merge] Replace guidance in email alert test

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -101,6 +101,12 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
   });
 
+  test("Check links to Get emails about this page", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
+    await page.goto("/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2");
+    await page.getByRole("button", { name: "Get emails about this page" }).first().click();
+    await expect(page.getByText("You need a GOV.UK One Login to get these emails.")).toBeVisible();
+  });
+
   test("signin", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/sign-in");
     await expect(page.getByRole("heading", { name: "Sign in to a service" })).toBeVisible();

--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -15,7 +15,7 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
   });
 
   test("Check links to Email Alert Frontend work", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
-    await page.goto("/guidance/waste-exemption-nwfd-2-temporary-storage-at-the-place-of-production--2");
+    await page.goto("/government/publications/budget-2016-documents");
     await page.getByRole("button", { name: "Get emails about this page" }).first().click();
     await expect(page.getByText("You need a GOV.UK One Login to get these emails.")).toBeVisible();
   });


### PR DESCRIPTION
# What

Replace `detailed_guide` example in `govenment-frontend` email-alert test with `publication` example and add the email-alert test to `frontend` tests.


# Why

As part of app consolidation, `detailed_guide` document is migrated from `government-frontend` to `frontend` in [PR](https://github.com/alphagov/frontend/pull/4860) and so the tests are updated accordingly.

[Trello card](https://trello.com/c/8HsfHbJ6)
