### PR TITLE
Update Publisher e2e to be specific with its page text search

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -8,7 +8,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
 
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Publisher")).toBeVisible();
+    await expect(page.locator(".govuk-header")).toHaveText("Publisher");
     await expect(page.locator("#publication-list-container")).toBeVisible();
   });
 


### PR DESCRIPTION
Previously we were checking for the existence of the text "publisher" without considering where that text was. As a result when we added a banner, the test would get confused and return multiple instances in a way not supported by the previous check.

Check has been updated to look within the specific header class.

Based on https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-text 