### PR TITLE
Update Publisher e2e test to look for correct element.

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -8,7 +8,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
 
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
-    await expect(page.locator(".govuk-header")).toHaveText("Publisher");
+    await expect(page.getByRole("heading", { name: "Publications" })).toBeVisible();
     await expect(page.locator("#publication-list-container")).toBeVisible();
   });
 


### PR DESCRIPTION
Previous attempts failed so we're aiming for the heading element specifically so we catch it standalong.