### PR TITLE
Update publisher e2e to look for correct element

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -8,7 +8,7 @@ test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
 
   test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Publications" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
     await expect(page.locator("#publication-list-container")).toBeVisible();
   });
 


### PR DESCRIPTION
Previous attempt at heading did not cover all bases, so trying it with a link target instead.