### PR TITLE
Disable Publisher tests during maintenance mode

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -6,15 +6,19 @@ import { publishingAppUrl } from "../lib/utils";
 test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test.use({ baseURL: publishingAppUrl("publisher") });
 
-  test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
-    await expect(page.locator("#publication-list-container")).toBeVisible();
-  });
+  test(
+    "Can log in to Publisher",
+    { tag: ["@app-publishing-api", "@publishing-app", "@not-integration"] },
+    async ({ page }) => {
+      await page.goto("/");
+      await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
+      await expect(page.locator("#publication-list-container")).toBeVisible();
+    }
+  );
 
   test(
     "Can add and delete an artefact in publisher",
-    { tag: ["@app-publisher", "@app-publishing-api", "@not-production"] },
+    { tag: ["@app-publisher", "@app-publishing-api", "@not-integration", "@not-production"] },
     async ({ page }) => {
       // Go to the "publisher" landing page
       await page.goto("/");


### PR DESCRIPTION
As part of the migration from MongoDB to PostgreSQL, Mainstream Publisher is having its UI disabled so that database changes are not occurring during the migration window. While the migration process is being tested in integration, disable the e2e tests so that deployments are not blocked.