### PR TITLE
feat: change target of email test

### DIFF
--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -15,7 +15,7 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
   });
 
   test("Check links to Email Alert Frontend work", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
-    await page.goto("/government/publications/budget-2016-documents");
+    await page.goto("/government/consultations/soft-drinks-industry-levy");
     await page.getByRole("button", { name: "Get emails about this page" }).first().click();
     await expect(page.getByText("You need a GOV.UK One Login to get these emails.")).toBeVisible();
   });


### PR DESCRIPTION
- current target for this test points to a page which is now moved to frontend, so update to point to a page which is still on government-frontend.

https://trello.com/c/utYFvGDW/781-move-publication-from-government-frontend-to-frontend