### PR TITLE
Remove link check from search test

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -24,6 +24,7 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     const searchBox = page.getByRole("search");
     await searchBox.getByLabel("Search").fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
-    await expect(page.locator("#app-all-content-finder a[href='/universal-credit']")).toBeVisible();
+    await expect(page).toHaveTitle("Search GOV.UK");
+    await expect(page.getByText("Universal Credit")).toBeVisible();
   });
 });

--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -26,5 +26,6 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     await searchBox.getByRole("button", { name: "Search" }).click();
     await expect(page).toHaveTitle("Search GOV.UK");
     await expect(page.getByText("Universal Credit")).toBeVisible();
+    await expect(page).toHaveCSS(".gem-c-document-list__item-metadata");
   });
 });


### PR DESCRIPTION
The specific results returned from a search request are determined by Google Vertex. Sometimes there are problems with their algorithms so the results returned are not the ones that we expect. This causes the tests to fail and blocks deployment.

We have other, more details evaluations that run to check the quality of search results, so we don't need to rely on the e2e test for that, instead we should check things we can control, such as the user journey (homepage to search page) being as expected.