### PR TITLE
Update expected title in site search test

### DIFF
--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -24,7 +24,7 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     const searchBox = page.getByRole("search");
     await searchBox.getByLabel("Search").fill("Universal Credit");
     await searchBox.getByRole("button", { name: "Search" }).click();
-    await expect(page).toHaveTitle("Search GOV.UK");
+    await expect(page).toHaveTitle("Universal Credit - Search - GOV.UK");
     await expect(page.getByText("Universal Credit")).toBeVisible();
     await expect(page).toHaveCSS(".gem-c-document-list__item-metadata");
   });


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/govuk-e2e-tests/pull/276

# What's changed?

Prepend the search query to the expected page title in the site search test.

# Why?

The expectation for the test was checking the viewable text in the H1 rather than the content in the title tag in the head element which contains the full search query entered by the user.

<img width="821" height="124" alt="Screenshot 2025-08-19 at 11 51 06" src="https://github.com/user-attachments/assets/d30eff7d-318d-4369-a6e2-4bde69dc6294" />
