### PR TITLE
Globally pin GitHub Actions actions to commit hashes not tags

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           show-progress: false
 


### PR DESCRIPTION
We agree that pinning the versions of GitHub Actions actions to a commit hash
instead of a mutable tag is the correct choice.

We have a lot of places where we use them. The changes in this commit were
generated by using a tool called pinact[1] which can convert pinned tags in GHA
workflows to the commit hash they point to at that moment in time.

To generate the change set I ran `pinact run` from the root of the repository.

[1] https://github.com/suzuki-shunsuke/pinact
