### PR TITLE
Disable tests for Publisher in staging

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -6,15 +6,19 @@ import { publishingAppUrl } from "../lib/utils";
 test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test.use({ baseURL: publishingAppUrl("publisher") });
 
-  test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
-    await expect(page.locator("#publication-list-container")).toBeVisible();
-  });
+  test(
+    "Can log in to Publisher",
+    { tag: ["@app-publishing-api", "@publishing-app", "@not-staging"] },
+    async ({ page }) => {
+      await page.goto("/");
+      await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
+      await expect(page.locator("#publication-list-container")).toBeVisible();
+    }
+  );
 
   test(
     "Can add and delete an artefact in publisher",
-    { tag: ["@app-publisher", "@app-publishing-api", "@not-production"] },
+    { tag: ["@app-publisher", "@app-publishing-api", "@not-staging", "@not-production"] },
     async ({ page }) => {
       // Go to the "publisher" landing page
       await page.goto("/");


### PR DESCRIPTION
We will be putting Publisher into 'maintenance mode' while we test migrating the data from MongoDB to PostgreSQL. During this time, the e2e tests would fail as the app UI is unavailable, therefore we are disabling the tests to prevent e2e test failures occuring.