### PR TITLE
Disable e2e tests in production for the final migration of publisher to postgres

### DIFF
--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -6,11 +6,15 @@ import { publishingAppUrl } from "../lib/utils";
 test.describe("Publisher", { tag: ["@app-publisher"] }, () => {
   test.use({ baseURL: publishingAppUrl("publisher") });
 
-  test("Can log in to Publisher", { tag: ["@app-publishing-api", "@publishing-app"] }, async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
-    await expect(page.locator("#publication-list-container")).toBeVisible();
-  });
+  test(
+    "Can log in to Publisher",
+    { tag: ["@app-publishing-api", "@publishing-app", "@not-production"] },
+    async ({ page }) => {
+      await page.goto("/");
+      await expect(page.getByRole("link", { name: "Publications" })).toBeVisible();
+      await expect(page.locator("#publication-list-container")).toBeVisible();
+    }
+  );
 
   test(
     "Can add and delete an artefact in publisher",


### PR DESCRIPTION
The Publisher to postgres migration on Production will be taking place today so we will need this PR in place and ready for when we put the app in maintenance mode later today. 