### PR TITLE
Delete footer test

### DIFF
--- a/tests/feedback.spec.js
+++ b/tests/feedback.spec.js
@@ -18,10 +18,4 @@ test.describe("Feedback", { tag: ["@app-feedback"] }, () => {
     const screenshot = await page.locator(".gem-c-layout-super-navigation-header").screenshot();
     expect(screenshot).toMatchSnapshot("expected-header.png", { maxDiffPixels: 100 });
   });
-
-  test("ensure the footer renders correctly", async ({ page }) => {
-    await page.goto("/contact/govuk");
-    const screenshot = await page.locator(".gem-c-layout-footer").screenshot();
-    expect(screenshot).toMatchSnapshot("expected-footer.png", { maxDiffPixels: 100 });
-  });
 });


### PR DESCRIPTION
Introduced in https://github.com/alphagov/govuk-e2e-tests/pull/259, but browsers render things slightly differently, and we can't predict how the e2e test operating system is rendering the footer so the tests are failing.