### PR TITLE
Update `collections` app test

### DIFF
--- a/tests/collections.spec.js
+++ b/tests/collections.spec.js
@@ -82,7 +82,6 @@ test.describe("Collections", { tag: ["@app-collections", "@domain-www"] }, () =>
   test("ministers", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/government/ministers");
     await expect(page.getByRole("heading", { name: "Ministers", exact: true })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Cabinet ministers", exact: true })).toBeVisible();
   });
 
   test("ministerial role", { tag: ["@worksonmirror"] }, async ({ page }) => {


### PR DESCRIPTION
## What
Remove the check for the "Cabinet ministers" heading from the "ministers" page test for the collections app.

## Why
This heading does not exist when the ministers page is updated, this causes the e2e test to fail and block deployments.

Checking for the presence of the "Ministers" heading should be enough and is [consistent with other page tests](https://github.com/alphagov/govuk-e2e-tests/blob/main/tests/collections.spec.js#L88-L91) for `collections`.