### PR TITLE
Disable chat tests in integration while I do DB maintenance

### DIFF
--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
-test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
+test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-integration"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can view a static page", async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
   });
 });
 
-test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat"] }, () => {
+test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat", "@not-integration"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can log in to chat admin", async ({ page }) => {


### PR DESCRIPTION
Chat in integration will be down for a couple of hours. Disable its tests in integration only while we do this work.