### PR TITLE
[DO NOT MERGE until maintenance] Disable chat e2e tests in production while DB maintenance is underwar

### DIFF
--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
-test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
+test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can view a static page", async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
   });
 });
 
-test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat"] }, () => {
+test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can log in to chat admin", async ({ page }) => {


### PR DESCRIPTION
Chat in prod will be down for up to 2 hours while we do DB maintenance. Disable the e2e tests for it so we don't block other e2e tests passing.