### PR TITLE
Replace /media path with /csv-preview for previewing CSV attachments

### DIFF
--- a/tests/assets.spec.js
+++ b/tests/assets.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { logIntoSignon, publishingAppUrl } from "../lib/utils";
 
-test.describe("Assets", { tag: ["@app-asset-manager", "@domain-assets", "@domain-www"] }, () => {
+test.describe("Whitehall Assets", { tag: ["@app-asset-manager", "@domain-assets", "@domain-www"] }, () => {
   test("whitehall assets are redirected", async ({ request }) => {
     const assetPath =
       "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf";
@@ -10,7 +10,9 @@ test.describe("Assets", { tag: ["@app-asset-manager", "@domain-assets", "@domain
     expect(response.status()).toBe(200);
     expect(response.url()).toBe(publishingAppUrl("assets") + assetPath);
   });
+});
 
+test.describe("Assets", { tag: ["@app-asset-manager", "@domain-assets"] }, () => {
   test("asset are served", async ({ request }) => {
     const response = await request.get("/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls");
     expect(response.status()).toBe(200);

--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -157,7 +157,7 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
   });
 
   test("csv previews for assets", { tag: ["@worksonmirror"] }, async ({ page }) => {
-    await page.goto("/media/5a7b9f8ced915d4147621960/passport-impact-indicat.csv/preview");
+    await page.goto("/csv-preview/5a7b9f8ced915d4147621960/passport-impact-indicat.csv");
     await expect(page.getByRole("heading", { name: "Passport impact indicators - CSV version" })).toBeVisible();
   });
 


### PR DESCRIPTION
We changed the logic for previewing CSV attachments and the preview page is now served by /csv-preview route.
We also want to remove the /media route from government-frontend that redirects all requests made from gov.uk/media to assets.publishing.gov.uk/media.