### PR TITLE
Revert "Disable chat e2e tests in production while DB maintenance is underwar"

### DIFF
--- a/tests/chat.spec.js
+++ b/tests/chat.spec.js
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import { test } from "../lib/cachebust-test";
 import { publishingAppUrl } from "../lib/utils";
 
-test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
+test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can view a static page", async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe("GOV.UK Chat", { tag: ["@app-govuk-chat", "@not-production"] }, ()
   });
 });
 
-test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat", "@not-production"] }, () => {
+test.describe("GOV.UK Chat Admin", { tag: ["@app-govuk-chat"] }, () => {
   test.use({ baseURL: publishingAppUrl("chat") });
 
   test("Can log in to chat admin", async ({ page }) => {


### PR DESCRIPTION
Reverts alphagov/govuk-e2e-tests#308

Once DB maintenance is complete and chat is back online, enable the e2e tests again in production