### PR TITLE
Check `application.css` referenced in `frontend` loads OK

### DIFF
--- a/tests/frontend.spec.js
+++ b/tests/frontend.spec.js
@@ -10,6 +10,15 @@ test.describe("Frontend", { tag: ["@app-frontend", "@domain-www"] }, () => {
     ).toBeVisible();
   });
 
+  test("check application CSS loads", { tag: ["@worksonmirror"] }, async ({ page, request }) => {
+    await page.goto("/");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/frontend/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("help page", { tag: ["@worksonmirror"] }, async ({ page }) => {
     await page.goto("/help");
     await expect(page.getByRole("heading", { name: "Help using GOV.UK" })).toBeVisible();


### PR DESCRIPTION
## What

Check `application.css` referenced in `frontend` loads OK

## Why

This test will help catch an issue where the application.css file uploaded, is not the same as the application.css file referenced in the HTML, which results in an unstyled page.

This is caused by a race condition which is a known issue - https://github.com/alphagov/govuk-infrastructure/issues/2447