### PR TITLE
Check application.css file loads in frontend apps

### DIFF
--- a/tests/collections.spec.js
+++ b/tests/collections.spec.js
@@ -13,6 +13,15 @@ test.describe("Collections", { tag: ["@app-collections", "@domain-www"] }, () =>
     await expect(page.getByRole("link", { name: "Apply to become a driving instructor" })).toBeVisible();
   });
 
+  test("check application CSS loads", async ({ page, request }) => {
+    await page.goto("/browse");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/collections/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("feeds", { tag: ["@worksonmirror"] }, async ({ request }) => {
     const response = await request.get("/government/feed");
     expect(response.status()).toBe(200);

--- a/tests/feedback.spec.js
+++ b/tests/feedback.spec.js
@@ -13,6 +13,15 @@ test.describe("Feedback", { tag: ["@app-feedback"] }, () => {
     await expect(page.getByRole("link", { name: "Please fill in this survey" })).toBeVisible();
   });
 
+  test("check application CSS loads", async ({ page, request }) => {
+    await page.goto("/contact/govuk");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/feedback/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("ensure the header renders correctly", async ({ page }) => {
     await page.goto("/contact/govuk");
     const screenshot = await page.locator(".gem-c-layout-super-navigation-header").screenshot();

--- a/tests/finder-frontend.spec.js
+++ b/tests/finder-frontend.spec.js
@@ -19,6 +19,15 @@ test.describe("Finder frontend", { tag: ["@app-finder-frontend"] }, () => {
     await expect(page.getByText("How often do you want to get emails?")).toBeVisible();
   });
 
+  test("check application CSS loads", async ({ page, request }) => {
+    await page.goto("/search/research-and-statistics");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/finder-frontend/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("Can use site search and receive results", async ({ page }) => {
     await page.goto("/");
     const searchBox = page.getByRole("search");

--- a/tests/government-frontend.spec.js
+++ b/tests/government-frontend.spec.js
@@ -14,6 +14,15 @@ test.describe("Government Frontend", { tag: ["@app-government-frontend"] }, () =
     ).toBeVisible();
   });
 
+  test("check application CSS loads", async ({ page, request }) => {
+    await page.goto("/government/topical-events/2014-overseas-territories-joint-ministerial-council/about");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/government-frontend/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("Check links to Email Alert Frontend work", { tag: ["@app-email-alert-frontend"] }, async ({ page }) => {
     await page.goto("/government/consultations/soft-drinks-industry-levy");
     await page.getByRole("button", { name: "Get emails about this page" }).first().click();

--- a/tests/smart-answers.spec.js
+++ b/tests/smart-answers.spec.js
@@ -16,6 +16,15 @@ test.describe("Smart Answers", { tag: ["@app-smartanswers"] }, () => {
     await expect(page.getByRole("heading", { name: /Information based on your answers/i })).toBeVisible();
   });
 
+  test("check application CSS loads", async ({ page, request }) => {
+    await page.goto("/vat-payment-deadlines");
+    const applicationCSSPath = await page
+      .locator('link[rel="stylesheet"][href*="/assets/smartanswers/application-"]')
+      .getAttribute("href");
+    const response = await request.get(`${applicationCSSPath}`);
+    expect(response.status()).toBe(200);
+  });
+
   test("Check the frontend can talk to Worldwide API", async ({ page }) => {
     await page.goto("/check-uk-visa");
     await page.getByRole("button", { name: "Start now" }).click();


### PR DESCRIPTION
## What

Check `application.css` file loads in frontend apps, with the exceptions of the apps below:

* **email-alert-frontend**: there is no test file in place for this application, we could add a similar check for a page that does not required you to be signed in, for example https://www.gov.uk/email/subscriptions/single-page/new?topic_id=keeping-a-pet-pig-or-micropig
* **static**: as static is manually deployed, there is no test file in place for static, and it seems very unlikely it will be impacted by the race condition issue as it is manually deployed

## Why

This test will help catch an issue where the application.css file uploaded, is not the same as the application.css file referenced in the HTML, which results in an unstyled page.

This is caused by a race condition which is a known issue - https://github.com/alphagov/govuk-infrastructure/issues/2447
