### PR TITLE
Update copy in CBM assertion

### DIFF
--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -76,7 +76,9 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await expect(page.getByRole("heading", { name: "Add an internal note" })).toBeVisible();
       await page.getByRole("button", { name: "Save and continue" }).click();
 
-      await expect(page.getByRole("heading", { name: "Do users have to know the content has changed?" })).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Do you need to tell users the content has changed?" })
+      ).toBeVisible();
       await page.getByLabel("No").check();
       await page.getByRole("button", { name: "Save and continue" }).click();
 


### PR DESCRIPTION
## Fix broken assertion in Content Block Manager tests

We [recently tweaked][] the message which is shown to ask editors whether a change needs to be communicated.

[recently tweaked]:
https://github.com/alphagov/content-block-manager/commit/41eb3cb8b6c28b322b7decc6be68dc0b5779b57e