### PR TITLE
Tidy up content block manager E2E tests

### DIFF
--- a/lib/content-block-manager-helpers.js
+++ b/lib/content-block-manager-helpers.js
@@ -1,0 +1,16 @@
+import { publishingAppUrl } from "../lib/utils";
+import { expect } from "@playwright/test";
+
+export const saveAndContinue = (page) => page.getByRole("button", { name: "Save and continue" }).click();
+
+export const verifyUpdatedRateVisible = async (page, updatedRate) =>
+  expect(async () => {
+    const url = await page.getByRole("link", { name: "Preview" }).getAttribute("href");
+
+    await page.goto(`${url}?cacheBust=${Date.now()}`);
+    await expect(page.getByText(updatedRate)).toBeVisible();
+  }, `Expected page to have value ${updatedRate}`).toPass();
+
+export const contentBlockPath = `${publishingAppUrl("content-block-manager")}/18`;
+export const whitehallPath = `${publishingAppUrl("whitehall-admin")}/government/admin/editions/1658299`;
+export const mainstreamPath = `${publishingAppUrl("publisher")}/editions/a3dc0cf7-00e4-4868-b0fd-2c33b4f47387`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,4 +8,16 @@ async function logIntoSignon(page) {
   await page.getByRole("button", { name: "Sign in" }).click();
 }
 
-export { publishingAppUrl, logIntoSignon };
+function useExponentialBackoffRetries(test) {
+  test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.status === testInfo.expectedStatus || testInfo.retry === testInfo.project.retries) return;
+
+    const delay = testInfo.timeout * 2 ** testInfo.retry;
+    testInfo.setTimeout(delay);
+
+    console.info(`Exponential backoff: waiting ${delay}ms before the next attempt`);
+    await page.waitForTimeout(delay);
+  });
+}
+
+export { publishingAppUrl, logIntoSignon, useExponentialBackoffRetries };

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -5,12 +5,13 @@ import { publishingAppUrl } from "../lib/utils";
 
 test.describe.configure({ mode: "serial" });
 
-async function verifyUpdatedRateVisible(page, url, updatedRate) {
-  await expect(async () => {
+const verifyUpdatedRateVisible = async (page, updatedRate) =>
+  expect(async () => {
+    const url = await page.getByRole("link", { name: "Preview" }).getAttribute("href");
+
     await page.goto(`${url}?cacheBust=${Date.now()}`);
     await expect(page.getByText(updatedRate)).toBeVisible();
   }, `Expected page to have value ${updatedRate}`).toPass();
-}
 
 test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, () => {
   // Double timeout to allow for occasional congestion in Publishing API queues
@@ -90,16 +91,12 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
 
     await test.step("Then I should be able to see the updated value on my Whitehall document", async () => {
       await page.goto(whitehallPath);
-      const url = await page.getByRole("link", { name: "Preview on website" }).getAttribute("href");
-
-      await verifyUpdatedRateVisible(page, url, newValue);
+      await verifyUpdatedRateVisible(page, newValue);
     });
 
     await test.step("And I should be able to see the updated value on my Mainstream document", async () => {
       await page.goto(mainstreamPath);
-      const url = await page.getByRole("link", { name: "Preview" }).getAttribute("href");
-
-      await verifyUpdatedRateVisible(page, url, newValue);
+      await verifyUpdatedRateVisible(page, newValue);
     });
   });
 });

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -21,14 +21,13 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
   const mainstreamPath = `${publishingAppUrl("publisher")}/editions/a3dc0cf7-00e4-4868-b0fd-2c33b4f47387`;
 
   test("Can embed an object", async ({ page }) => {
-    let embedCode;
     let newValue;
 
-    await test.step("Given I have a content block with an embed code", async () => {
+    const embedCode = await test.step("Given I have a content block with an embed code", async () => {
       await page.goto(contentBlockPath);
 
       const row = await page.getByTestId("rate_1_amount");
-      embedCode = await row.getAttribute("data-embed-code");
+      return row.getAttribute("data-embed-code");
     });
 
     await test.step("When I embed the block in Whitehall", async () => {

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -27,8 +27,11 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     const embedCode = await test.step("Given I have a content block with an embed code", async () => {
       await page.goto(contentBlockPath);
 
-      const row = await page.getByTestId("rate_1_amount");
-      return row.getAttribute("data-embed-code");
+      const row = page.getByTestId("rate_1_amount");
+      const code = await row.getAttribute("data-embed-code");
+
+      expect(code, "Unable to find valid embed code").not.toBeNull();
+      return code;
     });
 
     await test.step("When I embed the block in Whitehall", async () => {

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -22,7 +22,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
   const mainstreamPath = `${publishingAppUrl("publisher")}/editions/a3dc0cf7-00e4-4868-b0fd-2c33b4f47387`;
 
   test("Can embed an object", async ({ page }) => {
-    let newValue;
+    const newPensionRate = `£${(Math.random() * 100 + 100).toFixed(2)}`;
 
     const embedCode = await test.step("Given I have a content block with an embed code", async () => {
       await page.goto(contentBlockPath);
@@ -49,7 +49,6 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     });
 
     await test.step("When I update the block value", async () => {
-      newValue = `£${(Math.random() * (100.0 - 200.0) + 200.0).toFixed(2)}`;
       await page.goto(contentBlockPath);
 
       await page.getByRole("button", { name: "Edit pension" }).click();
@@ -62,7 +61,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
 
       await expect(page.getByRole("heading", { name: "Edit rate" })).toBeVisible();
       await page.getByLabel("Amount").click();
-      await page.getByLabel("Amount").fill(newValue);
+      await page.getByLabel("Amount").fill(newPensionRate);
       await page.getByRole("button", { name: "Save and continue" }).click();
 
       await expect(page.getByRole("heading", { name: "Edit rates" })).toBeVisible();
@@ -91,12 +90,12 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
 
     await test.step("Then I should be able to see the updated value on my Whitehall document", async () => {
       await page.goto(whitehallPath);
-      await verifyUpdatedRateVisible(page, newValue);
+      await verifyUpdatedRateVisible(page, newPensionRate);
     });
 
     await test.step("And I should be able to see the updated value on my Mainstream document", async () => {
       await page.goto(mainstreamPath);
-      await verifyUpdatedRateVisible(page, newValue);
+      await verifyUpdatedRateVisible(page, newPensionRate);
     });
   });
 });

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -55,38 +55,22 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await page.goto(contentBlockPath);
 
       await page.getByRole("button", { name: "Edit pension" }).click();
-
-      await expect(page.getByRole("heading", { name: "Edit pension" })).toBeVisible();
       await page.getByRole("button", { name: "Save and continue" }).click();
 
-      await expect(page.getByRole("heading", { name: "Edit rates" })).toBeVisible();
       await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
-
-      await expect(page.getByRole("heading", { name: "Edit rate" })).toBeVisible();
       await page.getByLabel("Amount").click();
       await page.getByLabel("Amount").fill(newPensionRate);
       await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await expect(page.getByRole("heading", { name: "Edit rates" })).toBeVisible();
+      await page.getByRole("button", { name: "Save and continue" }).click();
+      await page.getByRole("button", { name: "Save and continue" }).click();
       await page.getByRole("button", { name: "Save and continue" }).click();
 
-      await expect(page.getByRole("heading", { name: "Preview pension" })).toBeVisible();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await expect(page.getByRole("heading", { name: "Add an internal note" })).toBeVisible();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-
-      await expect(
-        page.getByRole("heading", { name: "Do you need to tell users the content has changed?" })
-      ).toBeVisible();
       await page.getByLabel("No").check();
       await page.getByRole("button", { name: "Save and continue" }).click();
 
-      await expect(page.getByRole("heading", { name: "Select publish date" })).toBeVisible();
       await page.getByLabel("Publish the edit now").check();
       await page.getByRole("button", { name: "Save and continue" }).click();
 
-      await expect(page.getByRole("heading", { name: "Review pension" })).toBeVisible();
       await page.getByLabel("confirm").check();
       await page.getByRole("button", { name: "Publish" }).click();
     });

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -1,27 +1,18 @@
 import { expect } from "@playwright/test";
-
 import { test } from "../lib/cachebust-test";
-import { publishingAppUrl } from "../lib/utils";
+import {
+  saveAndContinue,
+  verifyUpdatedRateVisible,
+  contentBlockPath,
+  mainstreamPath,
+  whitehallPath,
+} from "../lib/content-block-manager-helpers";
 
 test.describe.configure({ mode: "serial" });
-
-const saveAndContinue = (page) => page.getByRole("button", { name: "Save and continue" }).click();
-
-const verifyUpdatedRateVisible = async (page, updatedRate) =>
-  expect(async () => {
-    const url = await page.getByRole("link", { name: "Preview" }).getAttribute("href");
-
-    await page.goto(`${url}?cacheBust=${Date.now()}`);
-    await expect(page.getByText(updatedRate)).toBeVisible();
-  }, `Expected page to have value ${updatedRate}`).toPass();
 
 test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, () => {
   // Double timeout to allow for occasional congestion in Publishing API queues
   test.setTimeout(60_000);
-
-  const contentBlockPath = `${publishingAppUrl("content-block-manager")}/18`;
-  const whitehallPath = `${publishingAppUrl("whitehall-admin")}/government/admin/editions/1658299`;
-  const mainstreamPath = `${publishingAppUrl("publisher")}/editions/a3dc0cf7-00e4-4868-b0fd-2c33b4f47387`;
 
   test("Can embed an object", async ({ page }) => {
     const newPensionRate = `£${(Math.random() * 100 + 100).toFixed(2)}`;

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -56,25 +56,37 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     await test.step("When I update the block value", async () => {
       await page.goto(contentBlockPath);
 
-      await page.getByRole("button", { name: "Edit pension" }).click();
-      await saveAndContinue(page);
+      await test.step("And I choose to edit the existing pension", async () => {
+        await page.getByRole("button", { name: "Edit pension" }).click();
+        await saveAndContinue(page);
+      });
 
-      await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
-      await page.getByLabel("Amount").fill(newPensionRate);
-      await saveAndContinue(page);
+      await test.step("And I update the pension rate", async () => {
+        await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
+        await page.getByLabel("Amount").fill(newPensionRate);
+        await saveAndContinue(page);
+      });
 
-      await saveAndContinue(page);
-      await saveAndContinue(page);
-      await saveAndContinue(page);
+      await test.step("And I continue through the workflow to publish my changes", async () => {
+        await saveAndContinue(page);
+        await saveAndContinue(page);
+        await saveAndContinue(page);
+      });
 
-      await page.getByLabel("No").check();
-      await saveAndContinue(page);
+      await test.step("And I choose not to inform users of my minor edit", async () => {
+        await page.getByLabel("No").check();
+        await saveAndContinue(page);
+      });
 
-      await page.getByLabel("Publish the edit now").check();
-      await saveAndContinue(page);
+      await test.step("And I choose for my changes to be published immediately", async () => {
+        await page.getByLabel("Publish the edit now").check();
+        await saveAndContinue(page);
+      });
 
-      await page.getByLabel("confirm").check();
-      await page.getByRole("button", { name: "Publish" }).click();
+      await test.step("And I publish the changes", async () => {
+        await page.getByLabel("confirm").check();
+        await page.getByRole("button", { name: "Publish" }).click();
+      });
     });
 
     await test.step("Then I should be able to see the updated value on my Whitehall document", async () => {

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -50,7 +50,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       });
 
       await test.step("And I update the pension rate", async () => {
-        await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
+        await page.getByTestId("embedded_rate-1").getByRole("link", { name: "Edit" }).click();
         await page.getByLabel("Amount").fill(newPensionRate);
         await saveAndContinue(page);
       });

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -38,7 +38,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await page.goto(whitehallPath);
       await page.getByRole("button", { name: "Edit draft" }).click();
 
-      await page.getByLabel("Body (required)").fill(embedCode);
+      await page.getByRole("textbox", { name: "Body" }).fill(embedCode);
 
       await page.getByRole("button", { name: "Save and go to document" }).click();
     });
@@ -46,7 +46,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     await test.step("And I embed the block in Mainstream", async () => {
       await page.goto(mainstreamPath);
 
-      await page.getByLabel("More information").fill(embedCode);
+      await page.getByRole("textbox", { name: "More information" }).fill(embedCode);
 
       await page.getByRole("button", { name: "Save" }).click();
     });

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -60,7 +60,6 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await saveAndContinue(page);
 
       await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
-      await page.getByLabel("Amount").click();
       await page.getByLabel("Amount").fill(newPensionRate);
       await saveAndContinue(page);
 

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -34,7 +34,6 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await page.goto(whitehallPath);
       await page.getByRole("button", { name: "Edit draft" }).click();
 
-      await page.getByLabel("Body (required)").fill("");
       await page.getByLabel("Body (required)").fill(embedCode);
 
       await page.getByRole("button", { name: "Save and go to document" }).click();
@@ -43,7 +42,6 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     await test.step("And I embed the block in Mainstream", async () => {
       await page.goto(mainstreamPath);
 
-      await page.getByLabel("More information").fill("");
       await page.getByLabel("More information").fill(embedCode);
 
       await page.getByRole("button", { name: "Save" }).click();

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -7,12 +7,14 @@ import {
   mainstreamPath,
   whitehallPath,
 } from "../lib/content-block-manager-helpers";
+import { useExponentialBackoffRetries } from "../lib/utils";
 
-test.describe.configure({ mode: "serial" });
+test.describe.configure({ mode: "serial", retries: 3 });
 
 test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, () => {
   // Double timeout to allow for occasional congestion in Publishing API queues
   test.setTimeout(60_000);
+  useExponentialBackoffRetries(test);
 
   test("Can embed an object", async ({ page }) => {
     const newPensionRate = `£${(Math.random() * 100 + 100).toFixed(2)}`;

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -5,6 +5,8 @@ import { publishingAppUrl } from "../lib/utils";
 
 test.describe.configure({ mode: "serial" });
 
+const saveAndContinue = (page) => page.getByRole("button", { name: "Save and continue" }).click();
+
 const verifyUpdatedRateVisible = async (page, updatedRate) =>
   expect(async () => {
     const url = await page.getByRole("link", { name: "Preview" }).getAttribute("href");
@@ -55,21 +57,22 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await page.goto(contentBlockPath);
 
       await page.getByRole("button", { name: "Edit pension" }).click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
+      await saveAndContinue(page);
 
       await page.locator('[data-test-id="embedded_rate-1"]').getByRole("link", { name: "Edit" }).click();
       await page.getByLabel("Amount").click();
       await page.getByLabel("Amount").fill(newPensionRate);
-      await page.getByRole("button", { name: "Save and continue" }).click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
-      await page.getByRole("button", { name: "Save and continue" }).click();
+      await saveAndContinue(page);
+
+      await saveAndContinue(page);
+      await saveAndContinue(page);
+      await saveAndContinue(page);
 
       await page.getByLabel("No").check();
-      await page.getByRole("button", { name: "Save and continue" }).click();
+      await saveAndContinue(page);
 
       await page.getByLabel("Publish the edit now").check();
-      await page.getByRole("button", { name: "Save and continue" }).click();
+      await saveAndContinue(page);
 
       await page.getByLabel("confirm").check();
       await page.getByRole("button", { name: "Publish" }).click();

--- a/tests/content-block-manager.spec.js
+++ b/tests/content-block-manager.spec.js
@@ -30,9 +30,7 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
     await test.step("When I embed the block in Whitehall", async () => {
       await page.goto(whitehallPath);
       await page.getByRole("button", { name: "Edit draft" }).click();
-
       await page.getByRole("textbox", { name: "Body" }).fill(embedCode);
-
       await page.getByRole("button", { name: "Save and go to document" }).click();
     });
 
@@ -40,7 +38,6 @@ test.describe("Content Block Manager", { tag: ["@app-content-block-manager"] }, 
       await page.goto(mainstreamPath);
 
       await page.getByRole("textbox", { name: "More information" }).fill(embedCode);
-
       await page.getByRole("button", { name: "Save" }).click();
     });
 


### PR DESCRIPTION
# Jira Ticket
https://gov-uk.atlassian.net/browse/CM-958

# Description

Several changes here. Mostly around improving readability but also a slight enhancement to allow exponential backoff when our tests fail to help with publishing api queues.

One part of this was to add some more context to each part of the testing flow by describing parts of the process using playwright's `test.step`. Calls to `test.step` can be nested as appropriate. e.g.

```js
   ...
    await test.step("When I update the block value", async () => {
      await test.step("And I choose to edit the existing pension", async () => {
   ...
```
So the structure of the tests has been changed like so:
```diff
-"Can embed an object",
-    "Given I have a content block with an embed code"
-    "When I embed the block in Whitehall"
-    "And I embed the block in Mainstream"
-    "When I update the block value"
-    "Then I should be able to see the updated value on my Whitehall document"
-    "And I should be able to see the updated value on my Mainstream document"

+"Can embed an object",
+    "Given I have a content block with an embed code", 
+    "When I embed the block in Whitehall"
+    "And I embed the block in Mainstream"
+    "When I update the block value"
+        "And I choose to edit the existing pension"
+        "And I update the pension rate"
+        "And I continue through the workflow to publish my changes"
+        "And I choose not to inform users of my minor edit"
+        "And I choose for my changes to be published immediately"
+        "And I publish the changes"
+    "Then I should be able to see the updated value on my Whitehall document"
+    "And I should be able to see the updated value on my Mainstream document"
```
I think this gives more clarity on what's happening in the test and if any particular part of this were to fail, the user would have more context as to what was being attempted at the time.

Requires https://github.com/alphagov/content-block-manager/pull/671 to be merged before it will pass